### PR TITLE
Fixed new players being added on hiscores API end and spamming discord

### DIFF
--- a/APILogic.py
+++ b/APILogic.py
@@ -21,7 +21,7 @@ import time
 def api_call(player_name):
     """
     Assigning the base API url to a variable each time this function executes would waste memory and GC processing.
-    while loop is used as we need to keep the bot retrying the request so that it won't crash if internet goes
+    for loop is used as we need to keep the bot retrying the request so that it won't crash if internet goes
     down or if request failed. This is so if hosted on external server or device, it should retry 3 times before
     skipping the player, this should account for mispelled usernames and other issues without hanging endlessly.
     An interval of 60 seconds on failed requests as to not take up unnecessary cpu cycles
@@ -38,7 +38,7 @@ def api_call(player_name):
             # log requestexception
             print(f"\nError : Requests : Exception, \nError : {err}\nSleeping : 60 Seconds")
         else:
-            print(f"Error : Unhandled Exception, \nError : {err}\nSleeping : 60 Seconds")
+            print(f"\nError : Unhandled Exception, \nError : {err}\nSleeping : 60 Seconds")
         time.sleep(60)  # only executes if response != 200
     return None  # only return None if retries are exhausted and still failed
 

--- a/DiscordLogic.py
+++ b/DiscordLogic.py
@@ -115,7 +115,7 @@ class DiscordLogic:
         elif player_activity.type == Type.rifts:
             embed = DiscordEmbed(title=f"{player_obj.name} Closed A Rift",
                                  color=player_activity.colour)
-            embed.add_embed_field(name=f"{player_activity.name}",
+            embed.add_embed_field(name=f"{player_activity.name}    ",
                                   value=f"{int(player_activity.count):,} --> {int(buffer_activity.count):,}")
             embed.add_embed_field(name=f"Guardians Of The Rift Rank", value=f"{int(buffer_activity.rank):,}")
 

--- a/RuneBotMain.py
+++ b/RuneBotMain.py
@@ -44,10 +44,11 @@ def check_updated_stats(player_name):
     #skills
     for skill in skills_list:  # if new level is higher than previous level then push level update to discord
         if not players.username[player_name].__getattribute__(skill).level is None:
-            if (players.buffer.__getattribute__(skill).level
-                    > players.username[player_name].__getattribute__(skill).level):
-                discord.push_level_up(player_obj=players.username[player_name],
-                                      buffer_obj=players.buffer, skill_name=skill)
+            if not players.username[player_name].__getattribute__(skill).level is "-1":
+                if (players.buffer.__getattribute__(skill).level
+                        > players.username[player_name].__getattribute__(skill).level):
+                    discord.push_level_up(player_obj=players.username[player_name],
+                                          buffer_obj=players.buffer, skill_name=skill)
     #activities
     for activity in activity_list:  # if new count is higher than previous count then push activity update to discord
         if not players.username[player_name].__getattribute__(activity).count is None:


### PR DESCRIPTION
Jagex only adds new accounts to hiscores when they reach top 2 million in a single skill or activity. Discord would be spammed if this was the case as their skills would no longer be -1, they would instead be whatever they were updated to, the problem is that all of their data gets added at once, causing discord to be spammed. this was not considered during initial development and was only encountered recently, this should be fixed as not only if skill is None it will skip pushing the updates to discord but if the skill is -1 it will also skip pushing to discord. the skill has to be >0 prior to recent api call in order for the bot to push the message to discord.